### PR TITLE
fix: handle spaces within dmg titles

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = async path => {
     .trim()
     .split('\n')
     .pop()
-    .split(/\s+/)
+    .split(/\t+/)
   const unmount = () => exec(escape(['hdiutil', 'detach', diskPath]))
   return { diskPath, volumePath, unmount }
 }

--- a/index.js
+++ b/index.js
@@ -13,6 +13,7 @@ module.exports = async path => {
     .split('\n')
     .pop()
     .split(/\t+/)
+    .map(s => s.trim())
   const unmount = () => exec(escape(['hdiutil', 'detach', diskPath]))
   return { diskPath, volumePath, unmount }
 }


### PR DESCRIPTION
Fixes issue where dmg name has spaces in it and the current `split` incorrectly divides the string
Example:
```
/dev/disk3          	GUID_partition_scheme
/dev/disk3s1        	Apple_HFS                      	/Volumes/Test 5.8.0.9999
```
Using `\t` absorbs the tabs without breaking apart the `volumeName`